### PR TITLE
fix(deps): pin protobufjs to ^7.5.5 (CVE-2026-41242)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
     "posthog-js": "^1.369.2",
     "svelte": "^5.55.4",
     "vite": "^8.0.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "protobufjs": "^7.5.5"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs: ^7.5.5
+
 importers:
 
   .:
@@ -882,8 +885,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   query-selector-shadow-dom@1.0.1:
@@ -1181,7 +1184,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -1778,7 +1781,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary
- Patches CVE-2026-41242 (critical RCE via code injection in protobufjs, CVSS 9.4) by pinning `protobufjs` to `^7.5.5` via `pnpm.overrides`.
- `protobufjs` enters the tree transitively: `posthog-js` → `@opentelemetry/exporter-logs-otlp-http` → `@opentelemetry/otlp-transformer` → `protobufjs`. Upgrading `posthog-js` alone doesn't help — the latest (`1.369.5`) still pins `@opentelemetry/exporter-logs-otlp-http@^0.208.0`, which declares `protobufjs: ^7.3.0`. An override is the cleanest fix.

## Test plan
- [x] `pnpm why protobufjs` resolves to `7.5.5`
- [x] `pnpm build` succeeds
- [ ] `pnpm dev` serves the site without SSR errors